### PR TITLE
Swap Exception with Runtime Error to avoid MSVC extensions.

### DIFF
--- a/src/SWBF2/Chunks/StreamReader.hpp
+++ b/src/SWBF2/Chunks/StreamReader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <vector>
 #include <optional>
 #include <string>
@@ -47,7 +48,7 @@ namespace SWBF2
         StreamReader &operator>>(T &value)
         {
             if (IsEof() || (m_head + sizeof(T)) > m_header.size) {
-                throw std::exception("eof");
+                throw std::runtime_error("eof");
             }
 
             std::memcpy(&value, &m_data[m_head], sizeof(T));
@@ -64,7 +65,7 @@ namespace SWBF2
             std::size_t totalSize = vecSize * sizeof(T);
 
             if (IsEof() || (m_head + totalSize) > m_header.size) {
-                throw std::exception("eof");
+                throw std::runtime_error("eof");
             }
 
             std::memcpy(&value[0], &m_data[m_head], totalSize);


### PR DESCRIPTION
This PR improves the exception handling within the StreamReader.hpp file to ensure cross-platform compatibility. Specifically, it replaces the use of std::exception with std::runtime_error to avoid issues on non-MSVC compilers where std::exception does not accept a string parameter.